### PR TITLE
Add attribute rule scanning and auto-registration

### DIFF
--- a/Ruleflow.NET/Extensions/RuleflowOptions.cs
+++ b/Ruleflow.NET/Extensions/RuleflowOptions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Reflection;
 using Ruleflow.NET.Engine.Models.Rule.Interface;
 
 namespace Ruleflow.NET.Extensions
@@ -17,5 +18,24 @@ namespace Ruleflow.NET.Extensions
         /// If true, a default <see cref="IValidator{TInput}"/> built from registered rules will be registered.
         /// </summary>
         public bool RegisterDefaultValidator { get; set; }
+
+        /// <summary>
+        /// When true, rules and mapping information will be automatically loaded
+        /// from attributes discovered via reflection.
+        /// </summary>
+        public bool AutoRegisterAttributeRules { get; set; }
+
+        /// <summary>
+        /// Assemblies that will be scanned for <see cref="ValidationRuleAttribute"/>
+        /// declarations. If null, only the assembly containing <typeparamref name="TInput"/>
+        /// will be scanned.
+        /// </summary>
+        public IEnumerable<Assembly>? AssembliesToScan { get; set; }
+
+        /// <summary>
+        /// Optional namespace prefixes used to filter discovered types when
+        /// scanning for rules.
+        /// </summary>
+        public IEnumerable<string>? NamespaceFilters { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- extend `RuleflowOptions` with assembly/namespace scan settings
- scan assemblies for attributes in `AddRuleflow`
- auto-register attribute rules and mapping
- support namespace filtering in `AttributeRuleLoader`
- add unit tests for automatic registration

## Testing
- `dotnet test --no-restore Ruleflow.NET.Tests/Ruleflow.NET.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_685bb9408a8c83268099e4c0da1dbd43