### PR TITLE
Add logging support across engine components

### DIFF
--- a/Ruleflow.NET/Engine/Validation/Core/Validators/DependencyAwareValidator.cs
+++ b/Ruleflow.NET/Engine/Validation/Core/Validators/DependencyAwareValidator.cs
@@ -6,16 +6,20 @@ using Ruleflow.NET.Engine.Validation.Core.Context;
 using Ruleflow.NET.Engine.Validation.Core.Results;
 using Ruleflow.NET.Engine.Validation.Enums;
 using Ruleflow.NET.Engine.Validation.Interfaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Ruleflow.NET.Engine.Validation.Core.Validators
 {
     public class DependencyAwareValidator<T> : IValidator<T>
     {
         private readonly Dictionary<string, IValidationRule<T>> _rules;
+        private readonly ILogger<DependencyAwareValidator<T>> _logger;
 
-        public DependencyAwareValidator(IEnumerable<IValidationRule<T>> rules)
+        public DependencyAwareValidator(IEnumerable<IValidationRule<T>> rules, ILogger<DependencyAwareValidator<T>>? logger = null)
         {
             _rules = rules.ToDictionary(r => r.Id);
+            _logger = logger ?? NullLogger<DependencyAwareValidator<T>>.Instance;
             DetectCycles();
         }
 
@@ -77,11 +81,13 @@ namespace Ruleflow.NET.Engine.Validation.Core.Validators
             {
                 rule.Validate(input);
                 context.RuleResults[rule.Id] = new RuleExecutionResult { Success = true };
+                _logger.LogDebug("Rule {RuleId} executed successfully", rule.Id);
             }
             catch (Exception ex)
             {
                 context.RuleResults[rule.Id] = new RuleExecutionResult { Success = false };
                 result.AddError(ex.Message, rule.Severity);
+                _logger.LogError(ex, "Rule {RuleId} failed: {Message}", rule.Id, ex.Message);
             }
 
             cache[rule.Id] = result;
@@ -90,6 +96,7 @@ namespace Ruleflow.NET.Engine.Validation.Core.Validators
 
         public ValidationResult CollectValidationResults(T input)
         {
+            _logger.LogInformation("Starting validation of {InputType}", typeof(T).Name);
             var cache = new Dictionary<string, ValidationResult>();
             var final = new ValidationResult();
             foreach (var rule in _rules.Values.OrderByDescending(r => r.Priority))
@@ -97,6 +104,7 @@ namespace Ruleflow.NET.Engine.Validation.Core.Validators
                 var res = ExecuteRule(rule, input, cache);
                 final.AddErrors(res.Errors);
             }
+            _logger.LogInformation("Finished validation of {InputType}", typeof(T).Name);
             return final;
         }
 


### PR DESCRIPTION
## Summary
- inject `ILogger<T>` into validators, rule registry and event hub
- set up loggers using `ILoggerFactory` in `AddRuleflow`
- log rule registration, validation execution and errors
- default to `NullLogger<T>` when no logger provided

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685bee6c39e48326ab53b3d6de002501