### PR TITLE
Add LoggerFactory option

### DIFF
--- a/Ruleflow.NET.Tests/ServiceCollectionExtensionsTests.cs
+++ b/Ruleflow.NET.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,6 +1,8 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Ruleflow.NET.Engine.Validation;
 using Ruleflow.NET.Engine.Validation.Enums;
 using Ruleflow.NET.Extensions;
@@ -8,6 +10,7 @@ using Ruleflow.NET.Engine.Registry.Interface;
 using Ruleflow.NET.Engine.Validation.Interfaces;
 using Ruleflow.NET.Engine.Data.Enums;
 using Ruleflow.NET.Engine.Data.Mapping;
+using Ruleflow.NET.Engine.Events;
 
 namespace Ruleflow.NET.Tests
 {
@@ -102,6 +105,21 @@ namespace Ruleflow.NET.Tests
 
             Assert.IsNotNull(provider.GetRequiredService<IDataAutoMapper<Person>>());
             Assert.IsNotNull(provider.GetRequiredService<IValidator<Person>>());
+        }
+
+        [TestMethod]
+        public void AddRuleflow_WithLoggerFactory_UsesProvidedFactory()
+        {
+            var services = new ServiceCollection();
+            var loggerFactory = LoggerFactory.Create(builder => { });
+
+            services.AddRuleflow<Person>(o => o.LoggerFactory = loggerFactory);
+
+            var provider = services.BuildServiceProvider();
+
+            _ = provider.GetRequiredService<IRuleRegistry<Person>>();
+
+            Assert.AreNotSame(NullLogger<EventHub.EventHubLog>.Instance, EventHub.Logger);
         }
     }
 }

--- a/Ruleflow.NET/Extensions/RuleflowOptions.cs
+++ b/Ruleflow.NET/Extensions/RuleflowOptions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 using Ruleflow.NET.Engine.Models.Rule.Interface;
 
 namespace Ruleflow.NET.Extensions
@@ -41,5 +42,12 @@ namespace Ruleflow.NET.Extensions
         /// for attribute based rules.
         /// </summary>
         public IEnumerable<string>? NamespaceFilters { get; set; }
+
+        /// <summary>
+        /// Optional logger factory used when initializing Ruleflow services.
+        /// If null, any <see cref="ILoggerFactory"/> registered in the service
+        /// provider will be used, falling back to <see cref="NullLoggerFactory"/>.
+        /// </summary>
+        public ILoggerFactory? LoggerFactory { get; set; }
     }
 }

--- a/Ruleflow.NET/Extensions/ServiceCollectionExtensions.cs
+++ b/Ruleflow.NET/Extensions/ServiceCollectionExtensions.cs
@@ -45,7 +45,7 @@ namespace Ruleflow.NET.Extensions
 
             services.AddSingleton<IRuleRegistry<TInput>>(sp =>
             {
-                var loggerFactory = sp.GetService<ILoggerFactory>() ?? NullLoggerFactory.Instance;
+                var loggerFactory = options.LoggerFactory ?? sp.GetService<ILoggerFactory>() ?? NullLoggerFactory.Instance;
                 var logger = loggerFactory.CreateLogger<RuleRegistry<TInput>>();
                 var reg = new RuleRegistry<TInput>(options.InitialRules ?? Array.Empty<IRule<TInput>>(), logger);
 
@@ -109,7 +109,7 @@ namespace Ruleflow.NET.Extensions
                     }
                     foreach (var profile in profiles)
                         validationRules.AddRange(profile.ValidationRules);
-                    var loggerFactory = sp.GetService<ILoggerFactory>() ?? NullLoggerFactory.Instance;
+                    var loggerFactory = options.LoggerFactory ?? sp.GetService<ILoggerFactory>() ?? NullLoggerFactory.Instance;
                     var logger = loggerFactory.CreateLogger<Validator<TInput>>();
                     return new Validator<TInput>(validationRules, logger);
                 });


### PR DESCRIPTION
## Summary
- support configuring loggers via `RuleflowOptions` by adding `LoggerFactory` property
- use optional `LoggerFactory` when building registry and default validator
- test logger factory option

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bf132d2c083269f479a1d5dcadeab